### PR TITLE
Allow default value of false for Boolean properties

### DIFF
--- a/ripple/lib/ripple/attribute_methods.rb
+++ b/ripple/lib/ripple/attribute_methods.rb
@@ -102,7 +102,7 @@ module Ripple
 
       def attributes_from_property_defaults
         self.class.properties.values.inject({}) do |hash, prop|
-          hash[prop.key] = prop.default if prop.default
+          hash[prop.key] = prop.default unless prop.default.nil?
           hash
         end.with_indifferent_access
       end

--- a/ripple/lib/ripple/properties.rb
+++ b/ripple/lib/ripple/properties.rb
@@ -58,9 +58,10 @@ module Ripple
 
     # @return [Object] The default value for this property if defined, or nil.
     def default
-      if default = options[:default]
-        type_cast(default.respond_to?(:call) ? default.call : default)
-      end
+      default = options[:default]
+
+      return nil if default.nil?
+      type_cast(default.respond_to?(:call) ? default.call : default)
     end
 
     # @return [Hash] options appropriate for the validates class method

--- a/ripple/spec/ripple/attribute_methods_spec.rb
+++ b/ripple/spec/ripple/attribute_methods_spec.rb
@@ -15,7 +15,7 @@ require File.expand_path("../../spec_helper", __FILE__)
 
 describe Ripple::AttributeMethods do
   require 'support/models/widget'
-  
+
   before :each do
     @widget = Widget.new
   end
@@ -37,7 +37,7 @@ describe Ripple::AttributeMethods do
       @widget.attributes = {'key' => 'new-key'}
       @widget.key.should == 'widget-key'
     end
-    
+
     it "should typecast the key to a string" do
       @widget.key = 10
       @widget.key.should == "10"
@@ -56,8 +56,9 @@ describe Ripple::AttributeMethods do
 
     it "should return the property default if defined and not set" do
       @widget.name.should == "widget"
+      @widget.manufactured.should == false
     end
-    
+
     it "should allow raw attribute access when accessing the document with []" do
       @widget['name'].should == 'widget'
     end
@@ -78,7 +79,7 @@ describe Ripple::AttributeMethods do
       @widget.size = 10
       @widget.size.should == 10
     end
-    
+
     it "should allow assignment of undefined attributes when assigning to the document with []=" do
       @widget['name'] = 'sprocket'
       @widget.name.should == 'sprocket'
@@ -136,7 +137,7 @@ describe Ripple::AttributeMethods do
   end
 
   it "should provide a hash representation of all of the attributes" do
-    @widget.attributes.should == {"name" => "widget", "size" => nil}
+    @widget.attributes.should == {"name" => "widget", "size" => nil, "manufactured" => false}
   end
 
   it "should load attributes from mass assignment" do
@@ -154,24 +155,24 @@ describe Ripple::AttributeMethods do
     @widget = Widget.new(:name => "Riak")
     @widget.changes.should be_blank
   end
-  
+
   it "should allow adding to the @attributes hash for attributes that do not exist" do
     @widget = Widget.new
     @widget['foo'] = 'bar'
     @widget.instance_eval { @attributes['foo'] }.should == 'bar'
   end
-  
+
   it "should allow reading from the @attributes hash for attributes that do not exist" do
     @widget = Widget.new
     @widget['foo'] = 'bar'
     @widget['foo'].should == 'bar'
   end
-  
+
   it "should allow a block upon initialization to set attributes protected from mass assignment" do
     @widget = Widget.new { |w| w.key = 'some-key' }
     @widget.key.should == 'some-key'
   end
-  
+
   it "should raise an argument error when assigning a non hash to attributes" do
     @widget = Widget.new
     lambda { @widget.attributes = nil }.should raise_error(ArgumentError)

--- a/ripple/spec/ripple/properties_spec.rb
+++ b/ripple/spec/ripple/properties_spec.rb
@@ -77,6 +77,11 @@ describe Ripple::Property do
       prop.default.should == "bar"
     end
 
+    it "should allow false for a Boolean" do
+      prop = Ripple::Property.new('foo', Boolean, :default => false)
+      prop.default.should == false
+    end
+
     it "should allow lambdas for deferred evaluation" do
       prop = Ripple::Property.new('foo', String, :default => lambda { "bar" })
       prop.default.should == "bar"
@@ -122,11 +127,11 @@ describe Ripple::Property do
           @prop.type_cast([]).should == "[]"
         end
       end
-      
+
       it "should not cast nil" do
         @prop.type_cast(nil).should be_nil
       end
-    
+
     end
 
     describe "when type is an Integer type" do

--- a/ripple/spec/support/models/widget.rb
+++ b/ripple/spec/support/models/widget.rb
@@ -16,6 +16,7 @@ class Widget
   include Ripple::Document
   property :size, Integer
   property :name, String, :default => "widget"
+  property :manufactured, Boolean, :default => false
 end
 
 class Cog < Widget


### PR DESCRIPTION
Allow Boolean properties to have a default value of false.

Previously, this was the case:

```
class Widget
  include Ripple::Document
  property :manufactured, Boolean, :default => false
end

Widget.new.manufactured        # nil
```

Now it returns false.
