### PR TITLE
Casting the empty string in Numeric, Integer and Float properties

### DIFF
--- a/ripple/lib/ripple/core_ext/casting.rb
+++ b/ripple/lib/ripple/core_ext/casting.rb
@@ -30,7 +30,7 @@ end
 # @private
 class Numeric
   def self.ripple_cast(value)
-    return nil if value.nil?
+    return nil if value.nil? || value == ""
     raise Ripple::PropertyTypeMismatch.new(self,value) unless value.respond_to?(:to_i) && value.respond_to?(:to_f)
     float_value = value.to_f
     int_value = value.to_i
@@ -41,7 +41,7 @@ end
 # @private
 class Integer
   def self.ripple_cast(value)
-    return nil if value.nil?
+    return nil if value.nil? || value == ""
     value.respond_to?(:to_i) && value.to_i or raise Ripple::PropertyTypeMismatch.new(self, value)
   end
 end
@@ -49,7 +49,7 @@ end
 # @private
 class Float
   def self.ripple_cast(value)
-    return nil if value.nil?
+    return nil if value.nil? || value == ""
     value.respond_to?(:to_f) && value.to_f or raise Ripple::PropertyTypeMismatch.new(self, value)
   end
 end

--- a/ripple/spec/ripple/properties_spec.rb
+++ b/ripple/spec/ripple/properties_spec.rb
@@ -145,10 +145,14 @@ describe Ripple::Property do
         end
       end
 
-      [0.0, "0", "     000", ""].each do |v|
+      [0.0, "0", "     000"].each do |v|
         it "should cast #{v.inspect} to 0" do
           @prop.type_cast(v).should == 0
         end
+      end
+
+      it "should not cast the empty string" do
+        @prop.type_cast("").should be_nil
       end
 
       [true, false, [], ["something else"]].each do |v|
@@ -163,7 +167,7 @@ describe Ripple::Property do
         @prop = Ripple::Property.new(:foo, Float)
       end
 
-      [0, "0", "0.0", "    0.0", ""].each do |v|
+      [0, "0", "0.0", "    0.0"].each do |v|
         it "should cast #{v.inspect} to 0.0" do
           @prop.type_cast(v).should == 0.0
         end
@@ -173,6 +177,10 @@ describe Ripple::Property do
         it "should cast #{v.inspect} to 5.0" do
           @prop.type_cast(v).should == 5.0
         end
+      end
+
+      it "should not cast the empty string" do
+        @prop.type_cast("").should be_nil
       end
 
       [true, false, :symbol, [], {}].each do |v|
@@ -198,6 +206,11 @@ describe Ripple::Property do
           @prop.type_cast(v).should be_kind_of(Float)
         end
       end
+
+      it "should not cast the empty string" do
+        @prop.type_cast("").should be_nil
+      end
+
     end
 
     describe "when type is a Time type" do


### PR DESCRIPTION
Hi guys,

In this commit I changed the behaviour of casting the empty string in Numeric, Integer and Float properties. Even though in Ruby calling to_i on an empty string returns 0, I think that an empty string for such properties should be treated as a "missing" param.
In fact, the validation method 'validates_presence_of' at the moment returns true for empty strings, which I think is confusing.

What do you guys think?

Marco
