### PR TITLE
Untitled

### DIFF
--- a/riak-client/Rakefile
+++ b/riak-client/Rakefile
@@ -110,18 +110,18 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 
 desc "Run Unit Specs Only"
-Rspec::Core::RakeTask.new(:spec) do |spec|
+RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/riak/**/*_spec.rb"
 end
 
 namespace :spec do
   desc "Run Integration Specs Only"
-  Rspec::Core::RakeTask.new(:integration) do |spec|
+  RSpec::Core::RakeTask.new(:integration) do |spec|
     spec.pattern = "spec/integration/**/*_spec.rb"
   end
 
   desc "Run All Specs"
-  Rspec::Core::RakeTask.new(:all) do |spec|
+  RSpec::Core::RakeTask.new(:all) do |spec|
     spec.pattern = "spec/**/*_spec.rb"
   end
 end

--- a/riak-client/spec/spec_helper.rb
+++ b/riak-client/spec/spec_helper.rb
@@ -33,7 +33,7 @@ end
 
 Dir[File.join(File.dirname(__FILE__), "support", "*.rb")].each {|f| require f }
 
-Rspec.configure do |config|
+RSpec.configure do |config|
   config.mock_with :rspec
 
   config.before(:each) do

--- a/riak-sessions/Rakefile
+++ b/riak-sessions/Rakefile
@@ -62,7 +62,7 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 
 desc "Run Specs"
-Rspec::Core::RakeTask.new(:spec) do |spec|
+RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/**/*_spec.rb"
 end
 

--- a/riak-sessions/spec/spec_helper.rb
+++ b/riak-sessions/spec/spec_helper.rb
@@ -23,7 +23,7 @@ require 'rspec'
 
 Dir[File.join(File.dirname(__FILE__), "support", "*.rb")].each {|f| require f }
 
-Rspec.configure do |config|
+RSpec.configure do |config|
   config.mock_with :rspec
   config.after(:each) do
     $test_server.recycle if $test_server

--- a/ripple/Rakefile
+++ b/ripple/Rakefile
@@ -156,18 +156,18 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 
 desc "Run Unit Specs Only"
-Rspec::Core::RakeTask.new(:spec) do |spec|
+RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/ripple/**/*_spec.rb"
 end
 
 namespace :spec do
   desc "Run Integration Specs Only"
-  Rspec::Core::RakeTask.new(:integration) do |spec|
+  RSpec::Core::RakeTask.new(:integration) do |spec|
     spec.pattern = "spec/integration/**/*_spec.rb"
   end
 
   desc "Run All Specs"
-  Rspec::Core::RakeTask.new(:all) do |spec|
+  RSpec::Core::RakeTask.new(:all) do |spec|
     spec.pattern = "spec/**/*_spec.rb"
   end
 end

--- a/ripple/spec/spec_helper.rb
+++ b/ripple/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require 'rspec'
 
 Dir[File.join(File.dirname(__FILE__), "support", "*.rb")].each {|f| require f }
 
-Rspec.configure do |config|
+RSpec.configure do |config|
   config.mock_with :rspec
   config.after(:each) do
     $test_server.recycle if $test_server


### PR DESCRIPTION
The usage of the constant Rspec instead of RSpec causes some deprecation warnings:

```
/Users/stefan/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2383:in `load'

* Rspec is deprecated.
* RSpec is the new top-level module in RSpec-2
***************************************************************

*****************************************************************
DEPRECATION WARNING: you are using a deprecated constant that will
be removed from a future version of RSpec.

/Users/stefan/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:1882:in `in_namespace'

* Rspec is deprecated.
* RSpec is the new top-level module in RSpec-2
***************************************************************

*****************************************************************
DEPRECATION WARNING: you are using a deprecated constant that will
be removed from a future version of RSpec.

/Users/stefan/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:1882:in `in_namespace'

* Rspec is deprecated.
* RSpec is the new top-level module in RSpec-2
***************************************************************
```

By the way, I'm using RSpec 2.3.0.
