### PR TITLE
Bucket cache

### DIFF
--- a/riak-client/lib/riak/client.rb
+++ b/riak-client/lib/riak/client.rb
@@ -140,8 +140,11 @@ module Riak
       unless (options.keys - [:keys, :props]).empty?
         raise ArgumentError, "invalid options"
       end
-      response = http.get(200, prefix, escape(name), {:keys => false}.merge(options), {})
-      Bucket.new(self, name).load(response)
+      @@bucket_cache ||= {}
+      @@bucket_cache[[name, options]] ||= begin
+        response = http.get(200, prefix, escape(name), {:keys => false}.merge(options), {})
+        Bucket.new(self, name).load(response)
+      end
     end
     alias :[] :bucket
 

--- a/riak-client/spec/riak/client_spec.rb
+++ b/riak-client/spec/riak/client_spec.rb
@@ -185,6 +185,12 @@ describe Riak::Client do
       @http.should_receive(:get).with(200, "/riak/", "foo%2Fbar%20", {:keys => false}, {}).and_return(@payload)
       @client.bucket("foo/bar ", :keys => false)
     end
+
+    it "should memoize bucket parameters" do
+      @http.should_receive(:get).once.with(200, "/riak/", "baz", {:keys => false}, {}).and_return(@payload)
+      @client.bucket("baz")
+      @client.bucket("baz")
+    end
   end
 
   describe "storing a file" do

--- a/ripple/lib/ripple/document/bucket_access.rb
+++ b/ripple/lib/ripple/document/bucket_access.rb
@@ -25,7 +25,7 @@ module Ripple
 
       # @return [Riak::Bucket] The bucket assigned to this class.
       def bucket
-        Riak::Bucket.new(Ripple.client, bucket_name)
+        Ripple.client.bucket(bucket_name)
       end
 
       # Set the bucket name for this class and its subclasses.

--- a/ripple/spec/ripple/persistence_spec.rb
+++ b/ripple/spec/ripple/persistence_spec.rb
@@ -22,6 +22,7 @@ describe Ripple::Document::Persistence do
     @client.stub!(:http).and_return(@http)
     @bucket = Riak::Bucket.new(@client, "widgets")
     @client.stub!(:[]).and_return(@bucket)
+    @client.stub!(:bucket).and_return(@bucket)
     @widget = Widget.new(:size => 1000)
   end
 


### PR DESCRIPTION
Fixes issue #74, "Ripple does not get Bucket properties," by adding a cache on bucket lookups at the Riak::Client level.

I like it at the client level so that sometime in the future if someone wants to make it smarter, reloadable, etc, it'll be straightforward. Putting it at the document level seems like it could get out of sync with other documents in such a case.
