### PR TITLE
Use http_port rather than port from the config for the test server.

### DIFF
--- a/ripple/lib/rails/generators/ripple/test/templates/test_server.rb
+++ b/ripple/lib/rails/generators/ripple/test/templates/test_server.rb
@@ -13,7 +13,7 @@ module Ripple
             :map_cache_size => 0, # 0.14
             :vnode_cache_entries => 0 # 0.13
           },
-          :riak_core => { :web_port => Ripple.config[:port] || 8098 }
+          :riak_core => { :web_port => Ripple.config[:http_port] || 8098 }
         },
         :bin_dir => Ripple.config.delete(:bin_dir),
         :temp_dir => Rails.root + "tmp/riak_test_server"


### PR DESCRIPTION
Since the ripple.yml file has changed to specify `http_port` rather than `port`, the test server file needs to use the new `http_port` setting.
