### PR TITLE
Fix FailedRequest#is_json? to check the HTTP "Content-Length" header

### DIFF
--- a/riak-client/lib/riak/client/excon_backend.rb
+++ b/riak-client/lib/riak/client/excon_backend.rb
@@ -49,15 +49,16 @@ module Riak
         end
 
         response = connection.request(params, &block)
+        response_headers.initialize_http_header(response.headers)
+
         if valid_response?(expect, response.status)
-          response_headers.initialize_http_header(response.headers)
           result = {:headers => response_headers.to_hash, :code => response.status}
           if return_body?(method, response.status, block_given?)
             result[:body] = response.body
           end
           result
         else
-          raise HTTPFailedRequest.new(method, expect, response.status, response.headers, response.body)
+          raise HTTPFailedRequest.new(method, expect, response.status, response_headers.to_hash, response.body)
         end
       end
 


### PR DESCRIPTION
Myron and I were pairing yesterday on some map reduce queries and ran in this bug.  `Riak::HTTPFailedRequest#is_json?` was looking for the `content-type` header, when it's actually `Content-type` coming back from Riak.  Note the case difference.  When we had a map reduce error, we got a `got #<NoMethodError: undefined method`include?' for nil:NilClass>` back.
