### PR TITLE
Extending Set on core_ext without requiring it first

### DIFF
--- a/riak-client/lib/riak/core_ext/blank.rb
+++ b/riak-client/lib/riak/core_ext/blank.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 unless Object.new.respond_to? :blank?
   class Object
     def blank?


### PR DESCRIPTION
When I updated to 0.9.2 I could no longer use it, whenever I required 'riak' this happened

<pre><code>
irb(main):002:0> require 'riak'
NameError: undefined method `empty?' for class `Set'
    from /usr/local/Cellar/ruby/1.9.2-p180/lib/ruby/gems/1.9.1/gems/riak-client-0.9.2/lib/riak/core_ext/blank.rb:27:in `<class:Set>'
    from /usr/local/Cellar/ruby/1.9.2-p180/lib/ruby/gems/1.9.1/gems/riak-client-0.9.2/lib/riak/core_ext/blank.rb:26:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /usr/local/Cellar/ruby/1.9.2-p180/lib/ruby/gems/1.9.1/gems/riak-client-0.9.2/lib/riak/core_ext.rb:1:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from /usr/local/Cellar/ruby/1.9.2-p180/lib/ruby/gems/1.9.1/gems/riak-client-0.9.2/lib/riak.rb:16:in `<top (required)>'
    from <internal:lib/rubygems/custom_require>:33:in `require'
    from <internal:lib/rubygems/custom_require>:33:in `rescue in require'
    from <internal:lib/rubygems/custom_require>:29:in `require'
    from (irb):2
    from /usr/local/bin/irb:12:in `<main>'
</code></pre>

The issue is that on core_ext the Set class is extended without requiring it first.
