### PR TITLE
Change YAML serialization spec to use YAML.dump

### DIFF
--- a/riak-client/spec/riak/robject_spec.rb
+++ b/riak-client/spec/riak/robject_spec.rb
@@ -73,11 +73,11 @@ describe Riak::RObject do
       end
 
       it "should serialize into a YAML stream" do
-        @object.serialize({"foo" => "bar"}).should == "--- \nfoo: bar\n"
+        @object.serialize({"foo" => "bar"}).should == YAML.dump({"foo" => "bar"})
       end
 
       it "should deserialize a YAML stream" do
-        @object.deserialize("--- \nfoo: bar\n").should == {"foo" => "bar"}
+        @object.deserialize(YAML.dump({"foo" => "bar"})).should == {"foo" => "bar"}
       end
     end
 


### PR DESCRIPTION
When I ran the riak-client specs originally, I had one failing spec on the `it "should serialize into a YAML stream"` expectation. I think it's because I'm still using syck for YAML and I bet you guys are using psych?  Specifically I was seeing `---\nfoo: bar\n` when it was looking for `--- \nfoo: bar\n`.  Note the missing space after the `---` in the version I am seeing.

In any event, I changed the spec to simply dump with `YAML.dump` so it works with whatever YAML library you have installed.
