### PR TITLE
Prevent infinite recursion in the association before_save hook.

### DIFF
--- a/ripple/lib/ripple/associations.rb
+++ b/ripple/lib/ripple/associations.rb
@@ -267,9 +267,15 @@ module Ripple
       klass.before_save do
         proxy = send(_association_name)
 
-        if proxy.respond_to?(:loaded_documents)
-          proxy.loaded_documents.each do |document|
-            document.save if document.new? || document.changed?
+        if proxy.respond_to?(:loaded_documents) && !@_in_save_loaded_documents_callback
+          @_in_save_loaded_documents_callback = true
+
+          begin
+            proxy.loaded_documents.each do |document|
+              document.save if document.new? || document.changed?
+            end
+          ensure
+            remove_instance_variable(:@_in_save_loaded_documents_callback)
           end
         end
       end

--- a/ripple/spec/integration/ripple/associations_spec.rb
+++ b/ripple/spec/integration/ripple/associations_spec.rb
@@ -119,6 +119,22 @@ describe "Ripple Associations" do
     @user.friends.map(&:email).should == ['new-address@ripple.com']
   end
 
+  it "allows and autosaves transitive linked associations" do
+    friend = User.new(:email => 'user-friend@example.com')
+    friend.key = 'main-user-friend'
+    @user.key = 'main-user'
+    @user.friends << friend
+    friend.friends << @user
+
+    @user.save! # should save both since friend is new
+
+    found_user = User.find!(@user.key)
+    found_friend = User.find!(friend.key)
+
+    found_user.friends.should == [found_friend]
+    found_friend.friends.should == [found_user]
+  end
+
   after :each do
     User.destroy_all
   end


### PR DESCRIPTION
I was getting infinite recursion with transitive links.  Somehow I missed this with all my testing of my rcent changes.  This is a bit of a hack, but it's localized and guarantees infinite recursion won't occur.

I can merge this, but wanted to get feedback first.
