### PR TITLE
Send pbc messages with a single socket write

### DIFF
--- a/riak-client/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/riak-client/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -121,8 +121,8 @@ module Riak
       private
       def write_protobuff(code, message)
         encoded = message.encode
-        socket.write([encoded.length+1, MESSAGE_CODES.index(code)].pack("NC"))
-        socket.write(encoded)
+        header = [encoded.length+1, MESSAGE_CODES.index(code)].pack("NC")
+        socket.write(header + encoded)
       end
 
       def decode_response(*args)

--- a/riak-client/spec/riak/beefcake_protobuffs_backend_spec.rb
+++ b/riak-client/spec/riak/beefcake_protobuffs_backend_spec.rb
@@ -1,0 +1,40 @@
+require File.expand_path("../spec_helper", File.dirname(__FILE__))
+require 'riak/client/beefcake/messages'
+
+describe Riak::Client::BeefcakeProtobuffsBackend do
+  before :each do
+    @client = Riak::Client.new
+    @backend = Riak::Client::BeefcakeProtobuffsBackend.new(@client)
+    @backend.instance_variable_set(:@server_config, {})
+  end
+
+  it "should only write to the socket one time per request" do
+    exp_bucket, exp_keys = 'foo', ['bar']
+    mock_socket = mock("mock TCP socket")
+
+    @backend.stub!(:socket).and_return(mock_socket)
+    mock_socket.should_receive(:write).exactly(1).with do |param|
+      len, code = param[0,5].unpack("NC")
+      req = Riak::Client::BeefcakeProtobuffsBackend::RpbListKeysReq.decode(param[5..-1])
+      code == 17 && req.bucket == exp_bucket
+    end
+
+    responses = Array.new(2) do |index|
+      resp = Riak::Client::BeefcakeProtobuffsBackend::RpbListKeysResp.new
+      if index == 0
+        resp.keys = exp_keys
+      else
+        resp.done = true
+      end
+      resp
+    end
+
+    responses.each do |response|
+      encoded_response = response.encode
+      mock_socket.should_receive(:read).exactly(1).with(5).and_return([1 + encoded_response.length, 18].pack("NC"))
+      mock_socket.should_receive(:read).exactly(1).with(encoded_response.length).and_return(encoded_response)
+    end
+
+    @backend.list_keys(exp_bucket).should == exp_keys
+  end
+end


### PR DESCRIPTION
All,
The following change greatly improved the performance of the pbc backend on Linux (fc13) - it went from almost 10x slower than http to about 2x faster.

-Dan
