### PR TITLE
reduce request latency

### DIFF
--- a/riak-client/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/riak-client/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -121,8 +121,7 @@ module Riak
       private
       def write_protobuff(code, message)
         encoded = message.encode
-        socket.write([encoded.length+1, MESSAGE_CODES.index(code)].pack("NC"))
-        socket.write(encoded)
+        socket.write([encoded.length+1, MESSAGE_CODES.index(code), encoded.to_s].pack("NCa*"))
       end
 
       def decode_response(*args)

--- a/riak-client/lib/riak/client/protobuffs_backend.rb
+++ b/riak-client/lib/riak/client/protobuffs_backend.rb
@@ -62,7 +62,13 @@ module Riak
       end
 
       def socket
-        Thread.current[:riakpbc_socket] ||= TCPSocket.new(@client.host, @client.pb_port)
+        Thread.current[:riakpbc_socket] ||= new_socket
+      end
+
+      def new_socket
+        socket = TCPSocket.new(@client.host, @client.pb_port)
+        socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
+        socket
       end
 
       def reset_socket


### PR DESCRIPTION
Set TCP_NODELAY on beefcake sockets and send messages in a single write to reduce latency.

Average request time went from ~41ms to ~2ms.
