### PR TITLE
Ensure callbacks are propagated to embedded associated documents.

### DIFF
--- a/ripple/spec/ripple/callbacks_spec.rb
+++ b/ripple/spec/ripple/callbacks_spec.rb
@@ -36,6 +36,15 @@ describe Ripple::Callbacks do
       @box.save
     end
 
+    it "propagates callbacks to embedded associated documents" do
+      Box.before_save { $pinger.ping }
+      BoxSide.before_save { $pinger.ping }
+      $pinger.should_receive(:ping).exactly(2).times
+      @box = Box.new
+      @box.sides << BoxSide.new
+      @box.save
+    end
+
     it "should call create callbacks on save when the document is new" do
       Box.before_create { $pinger.ping }
       Box.after_create { $pinger.ping }
@@ -120,6 +129,7 @@ describe Ripple::Callbacks do
     after :each do
       [:save, :create, :update, :destroy, :validation].each do |type|
         Box.reset_callbacks(type)
+        BoxSide.reset_callbacks(type)
       end
     end
   end

--- a/ripple/spec/ripple/timestamps_spec.rb
+++ b/ripple/spec/ripple/timestamps_spec.rb
@@ -18,21 +18,21 @@ shared_examples_for "a timestamped model" do
   end
 
   it "sets the updated_at timestamp when the object is saved" do
-    subject.save
+    record_to_save.save
     subject.updated_at.should_not be_nil
   end
 
   it "updates the updated_at timestamp when the object is updated" do
-    subject.save
+    record_to_save.save
     start = subject.updated_at
-    subject.save
+    record_to_save.save
     subject.updated_at.should > start
   end
 
   it "does not update the created_at timestamp when the object is updated" do
-    subject.save
+    record_to_save.save
     start = subject.created_at
-    subject.save
+    record_to_save.save
     subject.created_at.should == start
   end
 end
@@ -44,19 +44,33 @@ describe Ripple::Timestamps do
   before(:each) { Ripple.client.stub!(:backend).and_return(backend) }
 
   context "for a Ripple::Document" do
-    subject { Clock.new }
-    it_behaves_like "a timestamped model"
+    it_behaves_like "a timestamped model" do
+      subject { Clock.new }
+      let(:record_to_save) { subject }
+    end
   end
 
-  context "for a Ripple::EmbeddedDocument" do
-    let(:clock) { Clock.new }
+  context "for a Ripple::EmbeddedDocument when directly saved" do
+    it_behaves_like "a timestamped model" do
+      let(:clock) { Clock.new }
+      subject { Mode.new }
+      let(:record_to_save) { subject }
 
-    subject do
-      Mode.new.tap do |m|
-        clock.modes << m
+      before(:each) do
+        clock.modes << subject
       end
     end
+  end
 
-    it_behaves_like "a timestamped model"
+  context "for a Ripple::EmbeddedDocument when the parent is saved" do
+    it_behaves_like "a timestamped model" do
+      let(:clock) { Clock.new }
+      subject { Mode.new }
+      let(:record_to_save) { clock }
+
+      before(:each) do
+        clock.modes << subject
+      end
+    end
   end
 end

--- a/ripple/spec/support/models/box.rb
+++ b/ripple/spec/support/models/box.rb
@@ -2,5 +2,12 @@
 class Box
   include Ripple::Document
   property :shape, String
+  many :sides, :class_name => 'BoxSide'
   timestamps!
+end
+
+class BoxSide
+  include Ripple::EmbeddedDocument
+  embedded_in :box
+  property :material, String
 end


### PR DESCRIPTION
If an embedded child document has a before_save hook, we need to ensure this runs when the parent document is saved.

I ran into this bug in our application :(.  It'd be helpful to have someone else look this over before I merge it in.
