### PR TITLE
mapreduce with protocol buffer backend returns nil for previous phases with keep=false

### DIFF
--- a/riak-client/lib/riak/client/beefcake_protobuffs_backend.rb
+++ b/riak-client/lib/riak/client/beefcake_protobuffs_backend.rb
@@ -115,7 +115,7 @@ module Riak
             results[msg.phase] += JSON.parse(msg.response)
           end
         end
-        block_given? || results.size == 1 ? results.first : results
+        block_given? || results.compact.size == 1 ? results.last : results
       end
 
       private

--- a/riak-client/spec/riak/beefcake_protobuffs_backend_spec.rb
+++ b/riak-client/spec/riak/beefcake_protobuffs_backend_spec.rb
@@ -38,3 +38,22 @@ describe Riak::Client::BeefcakeProtobuffsBackend do
     @backend.list_keys(exp_bucket).should == exp_keys
   end
 end
+
+describe Riak::Client::BeefcakeProtobuffsBackend, '#mapred' do
+  before(:each) do
+    @client = Riak::Client.new
+    @backend = Riak::Client::BeefcakeProtobuffsBackend.new(@client)
+    @backend.instance_variable_set(:@server_config, {})
+  end
+  
+  it "should not return nil for previous phases that don't return anything" do
+    socket = stub(:socket).as_null_object
+    socket.stub(:read).and_return(stub(:socket_header, :unpack => [2, 24]), stub(:socket_message), stub(:socket_header_2, :unpack => [0, 1]))
+    message = stub(:message, :phase => 1, :response => [{}].to_json)
+    message.stub(:done).and_return(false, true)
+    Riak::Client::BeefcakeProtobuffsBackend::RpbMapRedResp.stub(:decode => message)
+    TCPSocket.stub(:new => socket)
+    
+    @backend.mapred('').should == [{}]
+  end
+end


### PR DESCRIPTION
when doing a

```
Riak::MapReduce.new(Ripple.client).
  add(...).
  map("...").
  map("...", keep: true).run
```

with the protocol buffers backend the result looks like `[nil, <result>]` instead of `[<result>]`. with http it works as expected. this patch fixes it.
