### PR TITLE
split attributes= into attributes= and raw_attributes=

### DIFF
--- a/ripple/lib/ripple/attribute_methods.rb
+++ b/ripple/lib/ripple/attribute_methods.rb
@@ -53,9 +53,21 @@ module Ripple
 
       # Mass assign the document's attributes.
       # @param [Hash] attrs the attributes to assign
-      def attributes=(attrs, guard_protected_attrs = true)
+      def attributes=(attrs)
         raise ArgumentError, t('attribute_hash') unless Hash === attrs
-        (guard_protected_attrs ? sanitize_for_mass_assignment(attrs) : attrs).each do |k,v|
+        sanitize_for_mass_assignment(attrs).each do |k,v|
+          if respond_to?("#{k}=")
+            __send__("#{k}=",v)
+          else
+            raise ArgumentError, t('undefined_property', :prop => k, :class => self.class.name)
+          end
+        end
+      end
+
+      # @private
+      def raw_attributes=(attrs)
+        raise ArgumentError, t('attribute_hash') unless Hash === attrs
+        attrs.each do |k,v|
           next if k.to_sym == :key
           if respond_to?("#{k}=")
             __send__("#{k}=",v)

--- a/ripple/lib/ripple/document/finders.rb
+++ b/ripple/lib/ripple/document/finders.rb
@@ -112,7 +112,7 @@ module Ripple
           klass = robject.data['_type'].constantize rescue self
           klass.new.tap do |doc|
             doc.key = robject.key
-            doc.__send__(:attributes=, robject.data.except("_type"), false) if robject.data
+            doc.__send__(:raw_attributes=, robject.data.except("_type")) if robject.data
             doc.instance_variable_set(:@new, false)
             doc.instance_variable_set(:@robject, robject)
           end

--- a/ripple/lib/ripple/document/persistence.rb
+++ b/ripple/lib/ripple/document/persistence.rb
@@ -73,7 +73,7 @@ module Ripple
         def reload
           return self if new?
           robject.reload(:force => true)
-          self.__send__(:attributes=, @robject.data.except("_type"), false)
+          self.__send__(:raw_attributes=, @robject.data.except("_type"))
           reset_associations
           self
         end

--- a/ripple/lib/ripple/embedded_document/finders.rb
+++ b/ripple/lib/ripple/embedded_document/finders.rb
@@ -10,10 +10,12 @@ module Ripple
       module ClassMethods
         def instantiate(attrs)
           begin
-            klass = attrs['_type'].present? ? attrs['_type'].constantize : self
-            klass.new(attrs)
+            klass = attrs['_type'].present? ? attrs.delete('_type').constantize : self
           rescue NameError
-            new(attrs)
+            klass = self
+          end
+          klass.new.tap do |object|
+            object.raw_attributes = attrs
           end
         end
       end

--- a/ripple/lib/ripple/locale/en.yml
+++ b/ripple/lib/ripple/locale/en.yml
@@ -13,4 +13,5 @@ en:
     one_association_validation_error: "is invalid (%{association_errors})"
     many_association_validation_error: "are invalid (%{association_errors})"
     associated_document_error_summary: "for %{doc_type} %{doc_id}: %{errors}"
+    undefined_property: "Undefined property :%{prop} for class '%{class}'"
 

--- a/ripple/spec/ripple/attribute_methods_spec.rb
+++ b/ripple/spec/ripple/attribute_methods_spec.rb
@@ -183,9 +183,20 @@ describe Ripple::AttributeMethods do
     @widget.manufactured.should be_false
   end
 
-  it "should allow protected attributes to be mass assigned" do
+  it "should allow protected attributes to be mass assigned via raw_attributes=" do
     @widget = Widget.new
-    @widget.send(:attributes=, { :manufactured => true }, false)
+    @widget.send(:raw_attributes=, { :manufactured => true })
     @widget.manufactured.should be_true
   end
+
+  it "should allow mass assigning arbitrary attributes via raw_attributes" do
+    @widget = Widget.new
+    @widget.__send__(:raw_attributes=, :explode => '?BOOM')
+    @widget[:explode].should eq('?BOOM')
+  end
+
+  it "should raise an ArgumentError with an undefined property message when mass assigning a property that doesn't exist" do
+    lambda { @widget = Widget.new(:explode => '?BOOM') }.should raise_error(ArgumentError, %q[Undefined property :explode for class 'Widget'])
+  end
+
 end

--- a/ripple/spec/ripple/embedded_document/finders_spec.rb
+++ b/ripple/spec/ripple/embedded_document/finders_spec.rb
@@ -5,7 +5,7 @@ describe Ripple::EmbeddedDocument::Finders do
   require 'support/models/favorite'
 
   before :each do
-    @addr = Address.new
+    @address = Address.new
   end
 
   it "should instantiate a document" do


### PR DESCRIPTION
Updated api to use `attributes=` for external mass assignment and `raw_attributes=` for internal mass assignment.  Can someone look over this and give me a +/-?  Thanks.
