### PR TITLE
Support namespacing in Hash.to_param

### DIFF
--- a/riak-client/lib/riak/core_ext/to_param.rb
+++ b/riak-client/lib/riak/core_ext/to_param.rb
@@ -22,9 +22,9 @@ unless Object.new.respond_to? :to_query and Object.new.respond_to? :to_param
   end
 
   class Hash
-    def to_param
-      map do |key, value|
-        value.to_query(key)
+    def to_param(namespace = nil)
+      collect do |key, value|
+        value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end.sort * '&'
     end
   end

--- a/riak-client/spec/riak/core_ext/to_param_spec.rb
+++ b/riak-client/spec/riak/core_ext/to_param_spec.rb
@@ -1,0 +1,15 @@
+
+describe Riak do
+  require 'riak/core_ext/to_param'
+
+  it "should do param conversion correctly" do
+    { :name => 'David', :nationality => 'Danish' }.to_param.should == "name=David&nationality=Danish"
+  end
+
+  # Based on the activesupport implementation.
+  # https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/to_param.rb
+  it "should do param conversion correctly with a namespace" do
+    { :name => 'David', :nationality => 'Danish' }.to_param('user').should == "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
+  end
+
+end


### PR DESCRIPTION
Hi,

Using CanCan for Ripple::Document authorization seems to rely on namespacing in Hash.to_param, and including the CanCan gem breaks a lot of the rspec controller tests. 

Using the [activesupport to_param implementation](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/to_param.rb) fixes this.

Thanks for your hard work on Ripple!

```
Failure/Error: post :create, "object"=>"user", "entry"=>[{"uid"=>"551787304", "id"=>"551787304", "time"=>1305105927, "changed_fields"=>["likes"]}]
ArgumentError:
 wrong number of arguments (1 for 0)
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/riak-client-0.9.4/lib/riak/core_ext/to_param.rb:25:in `to_param'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/activesupport-3.0.7/lib/active_support/core_ext/object/to_query.rb:21:in `block in to_query'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/activesupport-3.0.7/lib/active_support/core_ext/object/to_query.rb:21:in `collect'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/activesupport-3.0.7/lib/active_support/core_ext/object/to_query.rb:21:in `to_query'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/riak-client-0.9.4/lib/riak/core_ext/to_param.rb:31:in `block in to_param'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/riak-client-0.9.4/lib/riak/core_ext/to_param.rb:30:in `each'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/riak-client-0.9.4/lib/riak/core_ext/to_param.rb:30:in `map'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/riak-client-0.9.4/lib/riak/core_ext/to_param.rb:30:in `to_param'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/actionpack-3.0.7/lib/action_controller/test_case.rb:167:in `assign_parameters'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/actionpack-3.0.7/lib/action_controller/test_case.rb:402:in `process'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/actionpack-3.0.7/lib/action_controller/test_case.rb:47:in `process'
# /Users/dave/.rvm/gems/ruby-1.9.2-p0@rails3/gems/actionpack-3.0.7/lib/action_controller/test_case.rb:355:in `post'
# ./spec/controllers/subscription_notifications_controller_spec.rb:17:in `block (2 levels) in <top (required)>'
```
