### PR TITLE
Add support for Riak::SessionStore and Rails 2.3

### DIFF
--- a/riak-sessions/lib/riak/session_store.rb
+++ b/riak-sessions/lib/riak/session_store.rb
@@ -73,6 +73,10 @@ module Riak
         return false if options[:drop]
         session_id = generate_sid
       elsif session_id.nil?
+        # Rails 2.3 kills the session id from the request when
+        # reset_session is called. Working around that by temp.
+        # storing it in the middleware and explicitly destroying it
+        # as it's not guaranteed that Riak expiry is enabled
         session_id = if @session_id
                        destroy_session(env, @session_id, options)
                      else


### PR DESCRIPTION
Rails 2.3 is a real bitch when it comes to Rack, so it required a bit of a workaround (memoizing the session id, since Rails 2.3 assumes a self-expiring session storage), which should not interfere with forward-compatibility.
