### PR TITLE
Fix the stream parser to support proper HTTP 1.1 chunked encoding w/ the hex chunk byte size.

### DIFF
--- a/riak-client/lib/riak/util/multipart/stream_parser.rb
+++ b/riak-client/lib/riak/util/multipart/stream_parser.rb
@@ -41,7 +41,7 @@ module Riak
 
         def get_boundary
           if @buffer =~ CAPTURE_BOUNDARY
-            @re = /\r?\n--#{Regexp.escape($1)}(?:--)?\r?\n/
+            @re = /(?:[a-fA-F0-9]+\r?\n)?\r?\n--#{Regexp.escape($1)}(?:--)?\r?\n/
             @buffer = $~.post_match
             buffering
           else

--- a/riak-client/spec/fixtures/multipart-mapreduce-with-chunking.txt
+++ b/riak-client/spec/fixtures/multipart-mapreduce-with-chunking.txt
@@ -1,0 +1,17 @@
+1bd
+
+--NT6cqYFYCfbYZsocVt15tNWCpG9
+Content-Type: application/json
+
+{"phase":0,"data":["source :gemcutter\n\ngem 'i18n'\ngem 'builder'\ngem 'rspec', \"~>2.0.0\"\ngem 'fakeweb', \">=1.2\"\ngem 'rack', '>=1.0'\ngem 'rake'\ngem 'bundler'\ngem 'excon', \"~>0.3.4\"\n\nif defined? JRUBY_VERSION\n  gem 'json'\n  gem 'jruby-openssl'\nelse\n  gem 'curb', '>=0.6'\n  gem 'yajl-ruby'\nend\n\ngroup :integration do\n  gem 'activesupport', '~>3.0'\nend\n"]}
+c9
+
+--NT6cqYFYCfbYZsocVt15tNWCpG9
+Content-Type: application/json
+
+{"phase":0,"data":["source \"http://rubygems.org\"\n\ngem 'rake'\ngem 'gollum-site'\ngem 'rdiscount'\ngem 'RedCloth'\ngem 'rspec'\n"]}
+
+21
+--NT6cqYFYCfbYZsocVt15tNWCpG9--
+
+0

--- a/riak-client/spec/riak/stream_parser_spec.rb
+++ b/riak-client/spec/riak/stream_parser_spec.rb
@@ -50,4 +50,14 @@ describe Riak::Util::Multipart::StreamParser do
     end
     parser.accept File.read("spec/fixtures/multipart-mapreduce.txt")
   end
+
+  it "works properly when chunked encoding includes the hex octet sizes" do
+    block.should_receive(:ping).twice.and_return(true)
+    parser = klass.new do |result|
+      block.ping
+      result[:headers]['content-type'].should include("application/json")
+      lambda { Riak::JSON.parse(result[:body]) }.should_not raise_error
+    end
+    parser.accept File.read("spec/fixtures/multipart-mapreduce-with-chunking.txt")
+  end
 end


### PR DESCRIPTION
We recently added an nginx proxy in front of each riak node and are relying on that to provide authentication.  It worked fine until we tried a streaming map reduce request...we started to get weird parse failures from riak-client.  After looking into it, here's what @fluxx discovered:
- Riak doesn't appear to include the chunk size identifiers, in spite of it being part of the HTTP 1.1 spec.  It doesn't appear to matter what HTTP version the client specifies.
- When you use [nginx as a proxy](http://wiki.nginx.org/HttpProxyModule), it speaks HTTP 1.0 to the backend server and HTTP 1.1 to the client.
- Apparently, part of nginx's proxy logic includes a 1.0 to 1.1 translator that adds the chunk size identifiers to the response as it is streamed back to the client.

The regex in the riak-client stream parser didn't play nice with the chunk size hex strings.  This fixes it.

On another note--it seems to me like it's a bug in riak that it was not already including them, as it's part of the spec.
