### PR TITLE
Add a #to_s method inside Ripple::Inspection that prints the document key

### DIFF
--- a/ripple/lib/ripple/inspection.rb
+++ b/ripple/lib/ripple/inspection.rb
@@ -3,11 +3,30 @@ require 'ripple'
 module Ripple
   # Makes IRB and other inspect output a bit friendlier
   module Inspection
+
     # A human-readable version of the {Ripple::Document} or {Ripple::EmbeddedDocument}
+    # plus attributes
     def inspect
       attribute_list = attributes_for_persistence.except("_type").map {|k,v| "#{k}=#{v.inspect}" }.join(' ')
-      identifier = self.class.embeddable? ? "" : ":#{key || '[new]'}"
-      "<#{self.class.name}#{identifier} #{attribute_list}>"
+      inspection_string(attribute_list)
     end
+
+    # A string representation of the {Ripple::Document} or {Ripple::EmbeddedDocument}
+    def to_s
+      inspection_string
+    end
+
+    private
+
+    def inspection_string(extra = nil)
+      body = self.class.name + persistance_identifier
+      body += " #{extra}" if extra
+      "<#{body}>"
+    end
+
+    def persistance_identifier
+      self.class.embeddable? ? "" : ":#{key || '[new]'}"
+    end
+
   end
 end

--- a/ripple/spec/ripple/inspection_spec.rb
+++ b/ripple/spec/ripple/inspection_spec.rb
@@ -4,32 +4,48 @@ describe Ripple::Inspection do
   require 'support/models/box'
   require 'support/models/address'
 
+  shared_examples_for 'an inspected document' do |method|
+
+    it "should include the class name in the inspect string" do
+      @box.send(method).should be_starts_with("<Box")
+    end
+
+    it "should include the key in the #{method} string for documents" do
+      @box.key = "square"
+      @box.send(method).should be_starts_with("<Box:square")
+    end
+
+    it "should indicate a new document when no key is specified" do
+      @box.send(method).should be_starts_with("<Box:[new]")
+    end
+
+    it "should not display a key for embedded documents" do
+      @address.send(method).should_not include("[new]")
+    end
+
+  end
+
   before :each do
     @box = Box.new
     @address = Address.new
   end
-  
-  it "should include the class name in the inspect string" do
-    @box.inspect.should be_starts_with("<Box")
-  end
-  
-  it "should include the key in the inspect string for documents" do
-    @box.key = "square"
-    @box.inspect.should be_starts_with("<Box:square")
-  end
-  
-  it "should indicate a new document when no key is specified" do
-    @box.inspect.should be_starts_with("<Box:[new]")
+
+  describe '#inspect' do
+
+    it_should_behave_like 'an inspected document', :inspect
+
+    it "should enumerate the document's properties and their values" do
+      @box.shape = "square"
+      @box.inspect.should include("shape=\"square\"")
+      @box.inspect.should include("created_at=")
+      @box.inspect.should include("updated_at=")
+    end
+
   end
 
-  it "should enumerate the document's properties and their values" do
-    @box.shape = "square"
-    @box.inspect.should include("shape=\"square\"")
-    @box.inspect.should include("created_at=")
-    @box.inspect.should include("updated_at=")
-  end
-  
-  it "should not display a key for embedded documents" do
-    @address.inspect.should_not include("[new]")
+  describe '#to_s' do
+
+    it_should_behave_like 'an inspected document', :to_s
+
   end
 end


### PR DESCRIPTION
This is a simple change that extends the `Ripple::Inspection` module to include support for `#to_s`.  Our main use case for supporting `#to_s` is that often times we'll have logging like the following:

``` ruby
log.info "Enqueueing job for #{document}"
```

Without support for `#to_s`, you get a `document` that looks like `#<Document:0x000000039951a8>`, which isn't very helpful.  Instead, a call to `#to_s` will print `<Document:key>` if the document is persisted, and `<Document:[new]>` if the document is new.

I based this commit off of master, but I'm happy to rebase it off of `0.9-stable` if you'd like it there instead.
