### PR TITLE
Fix PIPE_DIR on Riak 1.0.0

### DIFF
--- a/riak-client/lib/riak/node/generation.rb
+++ b/riak-client/lib/riak/node/generation.rb
@@ -76,7 +76,7 @@ module Riak
           line.sub!(/(RUNNER_ETC_DIR=)(.*)/, '\1' + etc.to_s)
           line.sub!(/(RUNNER_USER=)(.*)/, '\1')
           line.sub!(/(RUNNER_LOG_DIR=)(.*)/, '\1' + log.to_s)
-          line.sub!(/(PIPE_DIR=)(.*)/, '\1' + pipe.to_s + '/')
+          line.sub!(/(PIPE_DIR=)(.*)/, '\1' + pipe.to_s)
           if line.strip == "RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}"
             line = "RUNNER_BASE_DIR=#{source.parent.to_s}\n"
           end


### PR DESCRIPTION
The extra slash at the end of PIPE_DIR is causing the following error when spinning up a test server:

```
Device not configured - ~/Dropbox/Development/marketplace/tmp/riak_test_server/pipe/erlang.pipe.1.w (Errno::ENXIO)
~/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/pathname.rb:829:in `initialize'
~/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/pathname.rb:829:in `open'
~/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/pathname.rb:829:in `open'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/node/console.rb:43:in `block in initialize'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/node/console.rb:36:in `each'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/node/console.rb:36:in `initialize'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/node/console.rb:22:in `new'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/node/console.rb:22:in `open'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/node/control.rb:71:in `attach'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/test_server.rb:67:in `maybe_attach'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/riak-client/lib/riak/test_server.rb:38:in `start'
~/.rvm/gems/ruby-1.9.2-p180@marketplace/bundler/gems/ripple-4410bc0937db/ripple/lib/ripple/test_server.rb:14:in `setup'
~/Dropbox/Development/marketplace/features/support/ripple.rb:3:in `<top (required)>'
```

The enclosed pull request fixes this problem.
