### PR TITLE
Fixed missing new line in rails spec_helper generator

### DIFF
--- a/ripple/lib/rails/generators/ripple/test/test_generator.rb
+++ b/ripple/lib/rails/generators/ripple/test/test_generator.rb
@@ -15,7 +15,7 @@ module Ripple
       def create_rspec_file
         if File.file?(Rails.root + 'spec/spec_helper.rb')
           inject_into_file 'spec/spec_helper.rb', :before => /R[Ss]pec\.configure do \|config\|/ do
-            "require 'ripple/test_server'"
+            "require 'ripple/test_server'\n"
           end
           inject_into_file 'spec/spec_helper.rb', :after => /R[Ss]pec\.configure do \|config\|/ do
             "\n  config.before(:all){ Ripple::TestServer.setup }" +


### PR DESCRIPTION
Added a new line after the `require` line in the spec helper generator when you are using rspec in a rails app.
