### PR TITLE
Add documentation for the conflict resolution API.

### DIFF
--- a/riak-client/lib/riak/robject.rb
+++ b/riak-client/lib/riak/robject.rb
@@ -50,14 +50,29 @@ module Riak
     # @see http://wiki.basho.com/display/RIAK/REST+API#RESTAPI-Storeaneworexistingobjectwithakey Riak Rest API Docs
     attr_accessor :prevent_stale_writes
 
+    # Defines a callback to be invoked when there is conflict.
+    #
+    # @yield The conflict callback.
+    # @yieldparam [RObject] robject The conflicted RObject
+    # @yieldreturn [RObject, nil] Either the resolved RObject or nil if your
+    #                             callback cannot resolve it. The next registered
+    #                             callback will be given the chance to resolve it.
+    #
+    # @note Ripple registers its own document-level conflict handler, so if you're
+    #       using ripple, you will probably want to use that instead.
     def self.on_conflict(&conflict_hook)
       on_conflict_hooks << conflict_hook
     end
 
+    # @return [Array<Proc>] the list of registered conflict callbacks.
     def self.on_conflict_hooks
       @on_conflict_hooks ||= []
     end
 
+    # Attempts to resolve conflict using the registered conflict callbacks.
+    #
+    # @return [RObject] the RObject
+    # @note There is no guarantee the returned RObject will have been resolved
     def attempt_conflict_resolution
       return self unless conflict?
 

--- a/ripple/lib/ripple/conflict/document_hooks.rb
+++ b/ripple/lib/ripple/conflict/document_hooks.rb
@@ -4,13 +4,39 @@ module Ripple
       extend ActiveSupport::Concern
 
       module ClassMethods
+        # @return [Proc] the registered conflict handler
         attr_reader :on_conflict_block
 
+        # Registers a conflict handler for this model.
+        #
+        # @param [Array<Symbol>] expected_conflicts the list of properties and associations
+        #                        you expect to be in conflict.
+        # @yield the conflict handler block
+        # @yieldparam [Array<Ripple::Document>] siblings the sibling documents
+        # @yieldparam [Array<Symbol>] conflicts the properties and associations that could not
+        #                             be resolved by ripple's basic resolution logic.
+        #
+        # The block is instance_eval'd in the context of a partially resolved model instance.
+        # Thus, you should apply your resolution logic directly to self. Before calling
+        # your block, Ripple attempts some basic resolution on your behalf:
+        #
+        # * Any property or association for which all siblings agree will be set to the common value.
+        # * created_at will be set to the minimum value.
+        # * updated_at will be set to the maximum value.
+        # * All other properties and associations will be set to the default: nil or the default
+        #   value for a property, nil for a one association, and an empty array for a many association.
+        #
+        # Note that any conflict you do not resolve is a potential source of data loss (since ripple
+        # sets it to a default such as nil). It is recommended (but not required) that you pass the list
+        # of expected conflicts, as that informs ripple of what conflicts your block handles. If it detects
+        # conflicts for any other properties or associations, a NotImplementedError will be raised.
         def on_conflict(*expected_conflicts, &block)
           @expected_conflicts = expected_conflicts
           @on_conflict_block = block
         end
 
+        # @return [Array<Symbol>] list of properties and associations that are expected
+        #                         to be in conflict.
         def expected_conflicts
           @expected_conflicts ||= []
         end


### PR DESCRIPTION
Seeing @seancribbs' slides from his recent talk on eventual consistency and conflict resolution with riak/ripple reminded me that I never properly documented the conflict resolution API.

I've never used YARD before so hopefully this looks OK.
