### PR TITLE
Doc indexes

### DIFF
--- a/ripple/spec/ripple/indexes_spec.rb
+++ b/ripple/spec/ripple/indexes_spec.rb
@@ -4,11 +4,15 @@ describe Ripple::Indexes do
   context "class methods" do
     subject { Indexer }
     it { should respond_to(:indexes) }
-    it { should have(2).indexes }
+    it { should have(3).indexes }
 
     it "should remove the :index key from the property options" do
       subject.properties[:name].options.should_not include(:index)
       subject.properties[:age].options.should_not include(:index)
+    end
+
+    it "should not have a property for indexes" do
+      subject.properties[:name_age].should == nil
     end
   end
 
@@ -25,6 +29,7 @@ describe Ripple::Indexes do
       subject.robject.indexes.should_not be_empty
       subject.robject.indexes["name_bin"].should == Set["Bob"]
       subject.robject.indexes["age_int"].should == Set[28]
+      subject.robject.indexes["name_age_bin"].should == Set["Bob-28"]
     end
 
     context "when embedded documents have indexes" do

--- a/ripple/spec/support/models/indexer.rb
+++ b/ripple/spec/support/models/indexer.rb
@@ -11,4 +11,7 @@ class Indexer
   property :age, Fixnum, :index => true
   one :primary_address, :class => IndexedAddress
   many :addresses, :class => IndexedAddress
+  index :name_age, String do
+    "#{self.name}-#{self.age}"
+  end
 end


### PR DESCRIPTION
Added index method to Indexes::ClassMethods

Example:

``` ruby
class User
    include Ripple::Document

    property :firstname, String
    property :lastname, String

    index :fullname, String do
        "#{self.firstname} #{self.lastname}"
    end
end
```

Creates and persists a secondary index "fullname_bin" with the value as evaluated by the block.
