### PR TITLE
Fix undefined method errors in BeefcakeProtobuffsBackend

### DIFF
--- a/riak-client/lib/riak/client/protobuffs_backend.rb
+++ b/riak-client/lib/riak/client/protobuffs_backend.rb
@@ -8,6 +8,7 @@ module Riak
   class Client
     class ProtobuffsBackend
       include Util::Translation
+      include Util::Escape
 
       # Message Codes Enum
       MESSAGE_CODES = %W[

--- a/riak-client/spec/riak/beefcake_protobuffs_backend/object_methods_spec.rb
+++ b/riak-client/spec/riak/beefcake_protobuffs_backend/object_methods_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'riak/client/beefcake/object_methods'
+require 'riak/client/beefcake/messages'
+
+describe Riak::Client::BeefcakeProtobuffsBackend::ObjectMethods do
+  before :each do
+    @client = Riak::Client.new
+    @backend = Riak::Client::BeefcakeProtobuffsBackend.new(@client, @client.node)
+    @bucket = Riak::Bucket.new(@client, "bucket")
+    @object = Riak::RObject.new(@bucket, "bar")
+  end
+
+  describe "loading object data from the response" do
+    it "should load the key" do
+      content = stub(:value => '', :vtag => nil, :content_type => nil, :links => nil, :usermeta => nil, :last_mod => nil, :indexes => nil)
+      pbuf = stub(:vclock => nil, :content => [content], :value => nil, :key => 'akey')
+      o = @backend.load_object(pbuf, @object)
+      o.should == @object
+      o.key.should == pbuf.key
+    end
+  end
+
+end


### PR DESCRIPTION
Just a simple missing include, but I added a basic 
BeefcakeProtobuffsBackend#load_object test to reproduce the error too

(though beware my stubbing as I don't really know exactly what pb message
 data it was expecting).
