### PR TITLE
Add content_type to Basic Example.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,6 +68,7 @@ object = bucket.get_or_new("index.html")   # a Riak::RObject
 
 # Change the object's data and save
 object.data = "<html><body>Hello, world!</body></html>"
+object.content_type = "text/html"
 object.store
 
 # Reload an object you already have


### PR DESCRIPTION
Without the content_type, I get the following error as the initial object is created with a content type of application/json.

```
ruby-1.9.3-p0 :007 > object = bucket.get_or_new("index.html")
 => #<Riak::RObject {doc,index.html} [application/json]:nil> 
ruby-1.9.3-p0 :008 > object.data = "<html><body>Hello, world!</body></html>"
 => "<html><body>Hello, world!</body></html>" 
ruby-1.9.3-p0 :009 > object.store
JSON::ParserError: 743: unexpected token at '"<html><body>Hello, world!</body></html>"'
    from /Users/dczarnecki/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/json/common.rb:148:in `parse'
    from /Users/dczarnecki/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/json/common.rb:148:in `parse'
    from /Users/dczarnecki/.rvm/gems/ruby-1.9.3-p0@riak/gems/riak-client-0.9.8/lib/riak/robject.rb:222:in `deserialize'
    from /Users/dczarnecki/.rvm/gems/ruby-1.9.3-p0@riak/gems/riak-client-0.9.8/lib/riak/robject.rb:106:in `data'
    from /Users/dczarnecki/.rvm/gems/ruby-1.9.3-p0@riak/gems/riak-client-0.9.8/lib/riak/robject.rb:235:in `inspect'
    from /Users/dczarnecki/.rvm/rubies/ruby-1.9.3-p0/bin/irb:16:in `<main>'
```
