### PR TITLE
Fixed an issue if you tried to use the solr interface to enable_index! before any precommit actions are present

### DIFF
--- a/riak-client/lib/riak/bucket.rb
+++ b/riak-client/lib/riak/bucket.rb
@@ -189,7 +189,7 @@ module Riak
     # into riak_search.
     def enable_index!
       unless is_indexed?
-        self.props = {"precommit" => (props['precommit'] + [SEARCH_PRECOMMIT_HOOK]), "search" => true}
+        self.props = {"precommit" => ((props['precommit']||[]) + [SEARCH_PRECOMMIT_HOOK]), "search" => true}
       end
     end
 
@@ -197,7 +197,7 @@ module Riak
     # into riak_search.
     def disable_index!
       if is_indexed?
-        self.props = {"precommit" => (props['precommit'] - [SEARCH_PRECOMMIT_HOOK]), "search" => false}
+        self.props = {"precommit" => ((props['precommit']||[]) - [SEARCH_PRECOMMIT_HOOK]), "search" => false}
       end
     end
 
@@ -205,7 +205,7 @@ module Riak
     # riak_search.
     # @return [true,false] whether the bucket includes the search indexing hook
     def is_indexed?
-      props['search'] == true || props['precommit'].include?(SEARCH_PRECOMMIT_HOOK)
+      props['search'] == true || (props['precommit'] && props['precommit'].include?(SEARCH_PRECOMMIT_HOOK))
     end
 
     # @return [String] a representation suitable for IRB and debugging output


### PR DESCRIPTION
Fixed case where ripple via solr interface is used to enable searching when no precommit actions are present.
