### PR TITLE
fix cucumber test generator - will now generate support file

### DIFF
--- a/ripple/lib/rails/generators/ripple/test/templates/ripple.rb
+++ b/ripple/lib/rails/generators/ripple/test/templates/ripple.rb
@@ -1,0 +1,6 @@
+require 'ripple/test_server'
+Ripple::TestServer.setup
+
+After do
+  Ripple::TestServer.clear
+end

--- a/ripple/lib/rails/generators/ripple/test/test_generator.rb
+++ b/ripple/lib/rails/generators/ripple/test/test_generator.rb
@@ -7,7 +7,7 @@ module Ripple
       # Cucumber
       def create_cucumber_file
         if File.directory?(Rails.root + "features/support")
-          insert_into_file 'features/support/ripple.rb', "\n\nAfter do\n  Ripple::TestServer.clear\nend", :after => "Ripple::TestServer.setup"
+          template "ripple.rb", "features/support/ripple.rb"
         end
       end
 


### PR DESCRIPTION
this error would be thrown if a features/support/ripple.rb file was not found in the project

```
  insert  features/support/ripple.rb
```

/Users/reset/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/actions/inject_into_file.rb:99:in `binread': No such file or directory - /Users/reset/code/try-hard/features/support/ripple.rb (Errno::ENOENT)
    from /Users/reset/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/actions/inject_into_file.rb:99:in`replace!'
    from /Users/reset/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/actions/inject_into_file.rb:60:in `invoke!'
    from /Users/reset/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/actions.rb:95:in`action'

the ripple.rb support file needed to be created before it could be appended to. Upon further inspection the code actually was expecting something to exist requiring in ripple/test_server and setting it up. I couldn't find a reference to this anywhere else in the code base so I believe the correct thing to do is in this pull request. 

Simply generate a proper support file for cucumber.
