### PR TITLE
Decouple Ripple::TestServer from Rails.

### DIFF
--- a/ripple/lib/ripple/railtie.rb
+++ b/ripple/lib/ripple/railtie.rb
@@ -19,6 +19,7 @@ module Ripple
         # Make sure the TestServer lives in the default location, if
         # not set in the config file.
         Ripple.config[:root] ||= (Rails.root + 'tmp/riak_test_server').to_s
+        Ripple.config[:js_source_dir] ||= (Rails.root + "app/mapreduce").to_s
       end
     end
   end

--- a/ripple/lib/ripple/test_server.rb
+++ b/ripple/lib/ripple/test_server.rb
@@ -23,7 +23,7 @@ module Ripple
     def initialize(options=Ripple.config.dup)
       options[:env] ||= {}
       options[:env][:riak_kv] ||= {}
-      options[:env][:riak_kv][:js_source_dir] ||= Ripple.config.delete(:js_source_dir) || (Rails.root + "app/mapreduce").to_s
+      options[:env][:riak_kv][:js_source_dir] ||= Ripple.config.delete(:js_source_dir)
       options[:env][:riak_kv][:map_cache_size] ||= 0
       options[:env][:riak_core] ||= {}
       options[:env][:riak_core][:http] ||= [ Tuple[Ripple.config[:host], Ripple.config[:http_port]] ]


### PR DESCRIPTION
Removes mentions of `Rails.root` in `Ripple::TestServer`, instead moving those things to the railtie.
