### PR TITLE
RObject#inspect should also handle integer keys

### DIFF
--- a/riak-client/lib/riak/robject.rb
+++ b/riak-client/lib/riak/robject.rb
@@ -253,7 +253,7 @@ module Riak
              else
                @raw_data && "(#{@raw_data.size} bytes)"
              end
-      "#<#{self.class.name} {#{bucket.name}#{"," + @key if @key}} [#{@content_type}]:#{body}>"
+      "#<#{self.class.name} {#{bucket.name}#{"," + @key.to_s if @key}} [#{@content_type}]:#{body}>"
     end
 
     # Walks links from this object to other objects in Riak.

--- a/riak-client/spec/riak/robject_spec.rb
+++ b/riak-client/spec/riak/robject_spec.rb
@@ -388,6 +388,12 @@ describe Riak::RObject do
       object.inspect.should be_kind_of(String)
     end
 
+    it "should handle integer keys" do
+      object.key = 100
+      expect { object.inspect }.not_to raise_error
+      object.inspect.should be_kind_of(String)
+    end
+
     it 'uses the serializer output in inspect' do
       object.raw_data = { 'a' => 7 }
       object.content_type = 'inspect/type'


### PR DESCRIPTION
RObject#inspect currently fails if the key is an integer/Fixnum with "TypeError: can't convert Fixnum into String"
