### PR TITLE
Update lib/rails/generators/ripple/configuration/templates/ripple.yml

### DIFF
--- a/lib/rails/generators/ripple/configuration/templates/ripple.yml
+++ b/lib/rails/generators/ripple/configuration/templates/ripple.yml
@@ -3,6 +3,7 @@ development:
   http_port: 8098
   pb_port: 8087
   host: 127.0.0.1
+  source: /usr/local/bin  #Default for Homebrew.
 
 # The test environment has additional keys for configuring the
 # Riak::TestServer for your test/spec suite:


### PR DESCRIPTION
Using the default generated config/ripple.yml and running rake riak:create appears to require a "source:" attribute to be defined for each of the Rails environments.

eg

```
tim$ rake riak:create 
rake aborted!
Riak::Node configuration must include :source and :root keys.

Tasks: TOP => riak:create
(See full trace by running task with --trace)
```

I've simply updated ripple.yml so it defines source for the Rails development environment.

Full stack trace for your edification.

```
tim$ rake riak:create --trace
** Invoke riak:create (first_time)
** Invoke rails_env (first_time)
** Execute rails_env
** Execute riak:create
rake aborted!
Riak::Node configuration must include :source and :root keys.
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/riak-client-1.0.2/lib/riak/cluster.rb:29:in `initialize'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/bundler/gems/ripple-798b8983ec95/lib/ripple/railties/ripple.rake:102:in `new'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/bundler/gems/ripple-798b8983ec95/lib/ripple/railties/ripple.rake:102:in `cluster'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/bundler/gems/ripple-798b8983ec95/lib/ripple/railties/ripple.rake:22:in `block (2 levels) in <top (required)>'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
/Users/tim/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/task.rb:144:in `invoke'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:116:in `invoke_task'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block (2 levels) in top_level'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `each'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:94:in `block in top_level'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:88:in `top_level'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:66:in `block in run'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:133:in `standard_exception_handling'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/lib/rake/application.rb:63:in `run'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/gems/rake-0.9.2.2/bin/rake:33:in `<top (required)>'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/bin/rake:19:in `load'
/Users/tim/.rvm/gems/ruby-1.9.3-p125/bin/rake:19:in `<main>'
Tasks: TOP => riak:create
```
