### PR TITLE
Allow index blocks/methods to return nil, excluding index entry

### DIFF
--- a/lib/ripple/core_ext/indexes.rb
+++ b/lib/ripple/core_ext/indexes.rb
@@ -22,6 +22,13 @@ class Object
 end
 
 # @private
+class NilClass
+  def to_ripple_index(type)
+    self
+  end
+end
+
+# @private
 class Time
   def to_ripple_index(type)
     case type

--- a/lib/ripple/indexes.rb
+++ b/lib/ripple/indexes.rb
@@ -62,8 +62,10 @@ module Ripple
           else
             index_value = index.to_index_value send(key)
           end
-          index_value = Set[index_value] unless index_value.is_a?(Enumerable) && !index_value.is_a?(String)
-          indexes[prefix + index.index_key].merge index_value
+          unless index_value.nil?
+            index_value = Set[index_value] unless index_value.is_a?(Enumerable) && !index_value.is_a?(String)
+            indexes[prefix + index.index_key].merge index_value
+          end
         end
       end
     end

--- a/spec/ripple/indexes_spec.rb
+++ b/spec/ripple/indexes_spec.rb
@@ -16,6 +16,7 @@ describe Ripple::Indexes do
       subject.properties[:name_greeting].should == nil
     end
   end
+
   context "inherited indexes" do
     subject { SubIndexer }
     it { should have(5).indexes }
@@ -44,6 +45,13 @@ describe Ripple::Indexes do
       subject.robject.indexes["age_int"].should == Set[28]
       subject.robject.indexes["name_age_bin"].should == Set["Bob-28"]
       subject.robject.indexes["name_greeting_bin"].should == Set["Bob: Hello!"]
+    end
+
+    context "when an index value is nil" do
+      subject { Indexer.new(:name => nil, :age => 28) }
+      its(:indexes_for_persistence) { should_not include('name_bin') }
+      its(:indexes_for_persistence) { should_not include('name_age_bin') }
+      its(:indexes_for_persistence) { should_not include('name_greeting_bin') }
     end
 
     context "when embedded documents have indexes" do

--- a/spec/support/models/indexer.rb
+++ b/spec/support/models/indexer.rb
@@ -12,12 +12,16 @@ class Indexer
   one :primary_address, :class => IndexedAddress
   many :addresses, :class => IndexedAddress
   index :name_age, String do
-    "#{self.name}-#{self.age}"
+    if self.name && self.age
+      "#{self.name}-#{self.age}"
+    end
   end
   index :name_greeting, String
 
   def name_greeting
-    "#{name}: Hello!"
+    if name
+      "#{name}: Hello!"
+    end
   end
 end
 


### PR DESCRIPTION
This allows for patterns where the index should not be available on some documents that fail to meet certain criteria. I'd appreciate arguments for/against this change.  Some caveats to start the discussion:
- `nil` is treated specially to mean "don't index this". This doesn't allow patterns where you want to find documents that are _NOT_ indexed (a general problem).
- `nil` is checked specifically when adding the index entry to the persistence hash. Should falsey values be allowed instead? What is the implication of lumping `false` with `nil` in this case?

/cc @stevenbristol
