### PR TITLE
Gracefully handle conflicts for non-Ripple (riak-client) data

### DIFF
--- a/lib/ripple/conflict/resolver.rb
+++ b/lib/ripple/conflict/resolver.rb
@@ -11,7 +11,7 @@ module Ripple
 
       def self.to_proc
         @to_proc ||= lambda do |robject|
-          return nil unless robject.content_type=='application/json'
+          return nil unless robject.data.nil? or robject.content_type=='application/json'
           possible_model_classes = robject.siblings.map { |s| s.data && s.data['_type'] }.compact.uniq
           return nil unless possible_model_classes.size == 1
 


### PR DESCRIPTION
Sorry for another three line pull request. My application is mostly using Ripple, however some data is handled directly using riak-client.
There is no ['_type'] data for documents that are handled with the riak-client only. This small patch allows for conflicting data (allow_mult=true) and resolving it in riak-client only.
