### PR TITLE
[railties] [ripple] missing require for hash_with_indifferent_access

### DIFF
--- a/lib/ripple/railties/ripple.rake
+++ b/lib/ripple/railties/ripple.rake
@@ -1,3 +1,4 @@
+require 'active_support/hash_with_indifferent_access'
 require 'ripple/translation'
 require 'riak/cluster'
 require 'pp'


### PR DESCRIPTION
Got an exception bubbling up from cluster method in ripple.rake

```

[Sun, 08 Jul 2012 00:06:21 +0000] FATAL: Chef::Exceptions::Exec: deploy_revision[/var/www] (app::deploy line 43) had an error: Chef::Exceptions::Exec: bundle exec rake db:create db:migrate assets:precompile --trace returned 1, expected 0
---- Begin output of bundle exec rake db:create db:migrate assets:precompile --trace ----
STDOUT: STDERR: ** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Invoke rails_env (first_time)
** Execute rails_env
** Execute db:load_config
** Invoke riak:create (first_time)
** Invoke rails_env 
** Execute riak:create
rake aborted!
undefined method `with_indifferent_access' for nil:NilClass
/var/www/shared/bundle/ruby/1.9.1/gems/ripple-1.0.0.beta2/lib/ripple/railties/ripple.rake:99:in `cluster'
/var/www/shared/bundle/ruby/1.9.1/gems/ripple-1.0.0.beta2/lib/ripple/railties/ripple.rake:22:in `block (2 levels) in <top (required)>'
/var/www/shared/bundle/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `call'
/var/www/shared/bundle/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:205:in `block in execute'
/var/www/shared/bundle/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `each'
/var/www/shared/bundle/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:200:in `execute'
/var/www/shared/bundle/ruby/1.9.1/gems/rake-0.9.2.2/lib/rake/task.rb:158:in `block in invoke_with_call_chain'
/usr/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
```
