### PR TITLE
Do not replace accessors defined by superclass

### DIFF
--- a/lib/ripple/attribute_methods.rb
+++ b/lib/ripple/attribute_methods.rb
@@ -39,6 +39,12 @@ module Ripple
       def define_attribute_methods
         super(properties.keys)
       end
+
+      protected
+
+      def instance_method_already_implemented?(method_name)
+        method_defined?(method_name)
+      end
     end
 
     # A copy of the values of all attributes in the Document. The result

--- a/spec/ripple/attribute_methods_spec.rb
+++ b/spec/ripple/attribute_methods_spec.rb
@@ -61,6 +61,21 @@ describe Ripple::AttributeMethods do
       @widget.name.gsub!("w","f")
       @widget.name.should == "fidget"
     end
+
+    it "should not replace inherited accessors" do
+      parent = Class.new do
+        include Ripple::Document
+        def foo
+          "awesome"
+        end
+      end
+      parent.new.foo.should eq("awesome")
+
+      child = Class.new(parent) do
+        property :foo, String
+      end
+      child.new.foo.should eq("awesome")
+    end
   end
 
   describe "mutators" do


### PR DESCRIPTION
ActiveModel 3.2 was changed to only consider methods that it defines
when figuring out whether to override an accessor method. So:

  class Parent
    include Ripple::Document

```
def foo
  "awesome"
end
```

  end

  class Child < Parent
    property :foo
  end

  Child.new.foo #=> nil

This commit fixes it by reverting to the old behavior of not writing an
accessor it is already defined anywhere in the hierarchy. This does not
affect accessors created by ActiveModel itself, as those are undef'd
en masse before the method_defined? check is called.
