### PR TITLE
Support specifying the handoff_port in the ripple config.

### DIFF
--- a/lib/rails/generators/ripple/configuration/templates/ripple.yml
+++ b/lib/rails/generators/ripple/configuration/templates/ripple.yml
@@ -2,6 +2,7 @@
 development:
   http_port: 8098
   pb_port: 8087
+  handoff_port: 8080
   host: 127.0.0.1
   source: /usr/local/bin  #Default for Homebrew.
 
@@ -16,6 +17,7 @@ test:
   http_port: 9000
   pb_port: 9002
   host: 127.0.0.1
+  handoff_port: 8080
   source: /usr/local/bin   # Default for Homebrew.
   js_source_dir: <%%= Rails.root + "app/mapreduce" %>
 

--- a/lib/ripple/test_server.rb
+++ b/lib/ripple/test_server.rb
@@ -27,6 +27,7 @@ module Ripple
       options[:env][:riak_kv][:map_cache_size] ||= 0
       options[:env][:riak_core] ||= {}
       options[:env][:riak_core][:http] ||= [ Tuple[Ripple.config[:host], Ripple.config[:http_port]] ]
+      options[:env][:riak_core][:handoff_port] ||= Ripple.config[:handoff_port]
       options[:env][:riak_kv][:pb_port] ||= Ripple.config[:pb_port]
       options[:env][:riak_kv][:pb_ip] ||= Ripple.config[:host]
       super(options)


### PR DESCRIPTION
I had an issue with ripple in a new rails 3.2 app that stopped the test server that is generated in tmp/riak_test_server from starting. 

I tracked it down to a conflict with the default handoff_port. This adds the ability to modify that port, and more importantly I think provides the user a clear idea of an additional port that's needed to get their system up and running (in their test environment anyways).
