### PR TITLE
bump riak-client to 1.1.x

### DIFF
--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~>2.8.0"
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'ammeter', '~>0.2.2'
-  gem.add_dependency "riak-client", "~> 1.0.0"
+  gem.add_dependency "riak-client", "~> 1.1.0"
   gem.add_dependency "activesupport", [">= 3.0.0", "< 3.3.0"]
   gem.add_dependency "activemodel", [">= 3.0.0", "< 3.3.0"]
   gem.add_dependency "tzinfo"


### PR DESCRIPTION
We're trying to use ripple with JRuby 1.6.7.2 (ruby 1.9 mode).  ripple has a dependency on riak-client 1.0.x which has a JRuby specific bug that makes our tests hang (see: https://github.com/basho/riak-ruby-client/commit/84c272da2a760da5ad0a0c72c2be6a2b379b9dfc).  There is no tag in 1.0.x that contains the fix, so we need to use 1.1.x tag.
