### PR TITLE
RSpec example fails after updating rspec and ammeter dependencies

### DIFF
--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |gem|
   gem.authors = ["Sean Cribbs"]
 
   # Deps
-  gem.add_development_dependency "rspec", "~>2.8.0"
+  gem.add_development_dependency "rspec", "~>2.13.0"
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'ammeter', '~>0.2.2'
+  gem.add_development_dependency 'ammeter', '~>0.2.8'
   gem.add_dependency "riak-client", "~> 1.1.0"
   gem.add_dependency "activesupport", [">= 3.0.0", "< 3.3.0"]
   gem.add_dependency "activemodel", [">= 3.0.0", "< 3.3.0"]


### PR DESCRIPTION
I'm working on Rails 4 support for this library, and I've hit a small issue with a failing test case. I've tracked the problem back to the same test case failing on the master branch if the dependencies are updated.

I'm happy to continue investigating this, but I can't understand why the assertions in this test case are valid. I was hoping someone could shed some light on it for me.

The failure is [many_reference_proxy_spec.rb:145](https://github.com/basho/ripple/blob/master/spec/ripple/associations/many_reference_proxy_spec.rb#L145):

```
  1) Ripple::Associations::ManyReferenceProxy#keys maintains the list of keys properly as new documents are appended
     Failure/Error: @account.payment_methods.should have(1).key
       expected 1 key, got 3
      # ./spec/ripple/associations/many_reference_proxy_spec.rb:148:in `block (3 levels) in <top (required)>'
```

As far as I can see, the `@keys` collection in [ManyReferenceProxy](https://github.com/basho/ripple/blob/master/lib/ripple/associations/many_reference_proxy.rb) doesn't get updated when `<<` is called, so there will always be 3 keys (1, 2 and 3 as returned by the mock defined at line 120).

Anyone able to offer some advice?
