### PR TITLE
Don't use Module#=== explicitly

### DIFF
--- a/lib/ripple/associations.rb
+++ b/lib/ripple/associations.rb
@@ -323,11 +323,11 @@ module Ripple
     def type_matches?(value)
       case
       when polymorphic?
-        one? || Array === value
+        one? || value.is_a?(Array)
       when many?
-        Array === value && value.all? {|d| (embedded? && Hash === d) || d.kind_of?(klass) }
+        value.is_a?(Array) && value.all? {|d| (embedded? && d.is_a?(Hash)) || d.kind_of?(klass) }
       when one?
-        value.nil? || (embedded? && Hash === value) || value.kind_of?(klass)
+        value.nil? || (embedded? && value.is_a?(Hash)) || value.kind_of?(klass)
       end
     end
 


### PR DESCRIPTION
I still didn't figure out why Array === value return false when value is an array, but I have to send this pull request because someone else has the same problem: https://github.com/citrusbyte/ripple/commit/dc9c353c9df9a992bcab88d2f5703125a222e1e3

Using Module#=== explicitly isn't a good practice. In this case, value can be duck typing and overwrite the methods: is_a? and class, but Module#=== can't recognize it. I believe that's the reason why Array === value returns false.
