### PR TITLE
Update riak-client dependency to 1.4

### DIFF
--- a/ripple.gemspec
+++ b/ripple.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~>2.8.0"
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'ammeter', '~>0.2.2'
-  gem.add_dependency "riak-client", "~> 1.1"
+  gem.add_dependency "riak-client", "~> 1.4.0"
   gem.add_dependency "activesupport", [">= 3.0.0", "< 3.3.0"]
   gem.add_dependency "activemodel", [">= 3.0.0", "< 3.3.0"]
   gem.add_dependency "tzinfo"


### PR DESCRIPTION
The primary motivation is to allow ripple users to useadhoc erlang fns (see https://github.com/basho/riak-ruby-client/commit/1023ec1216f481d585d62758a0cce5981f6f222b)

This update passes all existing specs.  Given that this is not a change to expose new functionality for Ripple itself, but rather to allow the outside application to use an updated gem, I was unclear on any appropriate new specs.

I looked at the changes between Riak-client 1.1 and 1.4.0 and all API changes appear to be additions of new functions or new optional parameters, so it seems like the interface Ripple uses has not changed, and the specs appear to confirm that.
