### PR TITLE
Switched Gemfile source to HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
Switched Gemfile source to HTTP to quiet the `The source :rubygems is deprecated because HTTP requests are insecure.` Bundler error.
